### PR TITLE
Match new spacing rules in output

### DIFF
--- a/data/simple/bergamot/outputs/int8shiftAlphaAll/avx2/html-translation.expected
+++ b/data/simple/bergamot/outputs/int8shiftAlphaAll/avx2/html-translation.expected
@@ -1,6 +1,6 @@
-<div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div>
+
     
-    <h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
+    <div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div><h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
     <p>Das Bergamot-Projekt wird die maschinelle Übersetzung der Client-Seite in einem Webbrowser hinzufügen und verbessern.</p>
     <p>Im Gegensatz zu aktuellen Cloud-basierten Optionen, die direkt auf den Maschinen der Nutzer laufen, ermöglicht dies Bürger, ihre Privatsphäre zu bewahren und erhöht die Verbreitung von Sprachtechnologien in Europa in verschiedenen Sektoren, die Vertraulichkeit erfordern. Freie Software, die mit einem Open-Source-Webbrowser wie Mozilla Firefox integriert ist, ermöglicht die Annahme von Bottom-up durch Nicht-Experten, was zu Kosteneinsparungen für private und öffentliche Nutzer führt, die andernfalls Übersetzung beschaffen oder einstimmig arbeiten würden.</p>
     <p>Bergamot ist ein Konsortium, das von der Universität Edinburgh mit den Partnern der Charles University in Prag, der Universität Sheffield, der Universität Tartu und Mozilla koordiniert wird.</p></div>

--- a/data/simple/bergamot/outputs/int8shiftAlphaAll/avx512bw/html-translation.expected
+++ b/data/simple/bergamot/outputs/int8shiftAlphaAll/avx512bw/html-translation.expected
@@ -1,6 +1,6 @@
-<div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div>
+
     
-    <h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
+    <div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div><h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
     <p>Das Bergamot-Projekt wird die maschinelle Übersetzung der Client-Seite in einem Webbrowser hinzufügen und verbessern.</p>
     <p>Im Gegensatz zu aktuellen Cloud-basierten Optionen, die direkt auf den Maschinen der Nutzer laufen, ermöglicht dies Bürger, ihre Privatsphäre zu bewahren und erhöht die Verbreitung von Sprachtechnologien in Europa in verschiedenen Sektoren, die Vertraulichkeit erfordern. Freie Software, die mit einem Open-Source-Webbrowser wie Mozilla Firefox integriert ist, ermöglicht die Annahme von Bottom-up durch Nicht-Experten, was zu Kosteneinsparungen für private und öffentliche Nutzer führt, die andernfalls Übersetzung beschaffen oder einstimmig arbeiten würden.</p>
     <p>Bergamot ist ein Konsortium, das von der Universität Edinburgh mit den Partnern der Charles University in Prag, der Universität Sheffield, der Universität Tartu und Mozilla koordiniert wird.</p></div>

--- a/data/simple/bergamot/outputs/int8shiftAlphaAll/avx512vnni/html-translation.expected
+++ b/data/simple/bergamot/outputs/int8shiftAlphaAll/avx512vnni/html-translation.expected
@@ -1,6 +1,6 @@
-<div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div>
+
     
-    <h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
+    <div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div><h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
     <p>Das Bergamot-Projekt wird die maschinelle Übersetzung von Client-Side-Maschinen in einem Webbrowser hinzufügen und verbessern.</p>
     <p>Im Gegensatz zu aktuellen Cloud-basierten Optionen, die direkt auf den Maschinen der Nutzer laufen, befähigt die Bürger, ihre Privatsphäre zu bewahren und erhöht die Verbreitung von Sprachtechnologien in Europa in verschiedenen Sektoren, die Vertraulichkeit erfordern. Freie Software, die mit einem Open-Source-Webbrowser wie Mozilla Firefox integriert ist, wird die Annahme von Bottom-up durch Nicht-Experten ermöglichen, was zu Kosteneinsparungen für private und öffentliche Nutzer führt, die sonst Übersetzungen beschaffen oder einsprachig arbeiten würden.</p>
     <p>Bergamot ist ein Konsortium, das von der Universität Edinburgh mit den Partnern der Charles University in Prag, der Universität Sheffield, der Universität Tartu und Mozilla koordiniert wird.</p></div>

--- a/data/simple/bergamot/outputs/int8shiftAlphaAll/ssse3/html-translation.expected
+++ b/data/simple/bergamot/outputs/int8shiftAlphaAll/ssse3/html-translation.expected
@@ -1,6 +1,6 @@
-<div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div>
+
     
-    <h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
+    <div class="wrap"><div class="image-wrap"><img src="/images/about.jpg" alt=""></div><h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
     <p>Das Bergamot-Projekt wird die Übersetzung der Client-Seite der Maschine in einem Webbrowser ergänzen und verbessern.</p>
     <p>Im Gegensatz zu aktuellen Cloud-basierten Optionen, die direkt auf den Rechnern der Nutzer laufen, die Bürgerinnen und Bürger, ihre Privatsphäre zu bewahren und erhöht die Verbreitung von Sprachtechnologien in Europa in verschiedenen Sektoren, die Vertraulichkeit erfordern. Freie Software, die mit einem Open-Source-Webbrowser wie Mozilla Firefox integriert ist, wird die Akzeptanz von unten nach oben durch Nicht-Experten ermöglichen, was zu Kosteneinsparungen für private und öffentliche Nutzer führt, die andernfalls Übersetzungen beschaffen oder einsprachig arbeiten würden.</p>
     <p>Bergamot ist ein Konsortium, das von der Universität Edinburgh mit den Partnern Charles University in Prag, der University of Sheffield, der University of Tartu und Mozilla koordiniert wird.</p></div>


### PR DESCRIPTION
Update expected output to match latest changes in https://github.com/browsermt/bergamot-translator/pull/286.

Previously newlines weren't seen as whitespace, now they are. This change was necessary in bergamot-translator to make it possible to have negative-whitespace 'tags' that consume \n\n inserted by the HTML parser just before the translation. These are used to split block elements into their own paragraphs for the sentence splitter.